### PR TITLE
Fix GitHub icon in navbar for rmarkdown 2.6.

### DIFF
--- a/analysis/_site.yml
+++ b/analysis/_site.yml
@@ -42,7 +42,7 @@ navbar:
     - text: License
       href: license.html
   right:
-  - icon: fa-github
+  - icon: fab fa-github
     text: Source code
     href: https://github.com/wolfemd/PredictOutbredCrossVar
 output:


### PR DESCRIPTION
Nice workflowr site! I noticed that your GitHub icon in the navigation bar was broken. This is caused by a recent change in rmarkdown version 2.6. I've [fixed the problem in the development version of workflowr](https://github.com/jdblischak/workflowr/issues/231), but it's not yet on CRAN. This PR updates `_site.yml` to work with rmarkdown 2.6. To update the pages in your website to fix the icon, you can run:

```
wflow_publish(republish = TRUE)
```

